### PR TITLE
Add icon size option to Buttons

### DIFF
--- a/src/lib/dusk/components/AnchorButton/AnchorButton.svelte
+++ b/src/lib/dusk/components/AnchorButton/AnchorButton.svelte
@@ -51,9 +51,9 @@
 		{#if text}
 			<span class="dusk-anchor-button__text">{text}</span>
 		{/if}
-		<Icon className="dusk-anchor-button__icon" path={icon.path}/>
+		<Icon className="dusk-anchor-button__icon" path={icon.path} size={icon.size}/>
 	{:else if icon}
-		<Icon className="dusk-anchor-button__icon" path={icon.path}/>
+		<Icon className="dusk-anchor-button__icon" path={icon.path} size={icon.size}/>
 		{#if text}
 			<span class="dusk-anchor-button__text">{text}</span>
 		{/if}

--- a/src/lib/dusk/components/Button/Button.svelte
+++ b/src/lib/dusk/components/Button/Button.svelte
@@ -50,9 +50,9 @@
 		{#if text}
 			<span class="dusk-button__text">{text}</span>
 		{/if}
-		<Icon className="dusk-button__icon" path={icon.path}/>
+		<Icon className="dusk-button__icon" path={icon.path} size={icon.size}/>
 	{:else if icon}
-		<Icon className="dusk-button__icon" path={icon.path}/>
+		<Icon className="dusk-button__icon" path={icon.path} size={icon.size}/>
 		{#if text}
 			<span class="dusk-button__text">{text}</span>
 		{/if}

--- a/src/lib/dusk/components/dusk.components.d.ts
+++ b/src/lib/dusk/components/dusk.components.d.ts
@@ -2,6 +2,7 @@
 type ButtonIconProp = {
   path: string,
   position?: "after" | "before"
+  size?: IconSize,
 }
 
 type ButtonSize = "normal" | "small";

--- a/src/routes/(app)/dashboard/+layout.svelte
+++ b/src/routes/(app)/dashboard/+layout.svelte
@@ -7,14 +7,14 @@
 	<slot/>
 	<footer class="footer">
 		<nav class="footer__navigation">
-			<div>
-				<Icon className="footer__network-icon" path={mdiLinkCircle}/>
-				Dusk Testnet
+			<div class="footer__network-status">
+				<Icon className="footer__network-icon" path={mdiLinkCircle} size="large"/>
+				<p>Dusk Testnet</p>
 			</div>
 			<AnchorButton
 				variant="text"
 				className="footer__anchor-button"
-				icon={{ path: mdiCogOutline }}
+				icon={{ path: mdiCogOutline, size: "large" }}
 				href="/settings"
 				aria-label="Settings"
 				data-tooltip-id="main-tooltip"
@@ -36,6 +36,13 @@
 
 	.footer {
 		width: 100%;
+
+		&__network-status {
+			display: flex;
+			align-items: center;
+			gap: var(--small-gap);
+			line-height: 0;
+		}
 
 		&__navigation {
 			display: flex;

--- a/src/routes/(app)/dashboard/__tests__/__snapshots__/layout.spec.js.snap
+++ b/src/routes/(app)/dashboard/__tests__/__snapshots__/layout.spec.js.snap
@@ -16,10 +16,10 @@ exports[`Dashboard Layout > should render the dashboard layout 1`] = `
         class="footer__navigation s-Ck0voT_hIlXn"
       >
         <div
-          class="s-Ck0voT_hIlXn"
+          class="footer__network-status s-Ck0voT_hIlXn"
         >
           <svg
-            class="dusk-icon dusk-icon--size--normal footer__network-icon"
+            class="dusk-icon dusk-icon--size--large footer__network-icon"
             role="graphics-symbol"
             viewBox="0 0 24 24"
           >
@@ -29,8 +29,12 @@ exports[`Dashboard Layout > should render the dashboard layout 1`] = `
           </svg>
           
           <!--&lt;Icon&gt;-->
-          
-				Dusk Testnet
+           
+          <p
+            class="s-Ck0voT_hIlXn"
+          >
+            Dusk Testnet
+          </p>
         </div>
          
         <a
@@ -43,7 +47,7 @@ exports[`Dashboard Layout > should render the dashboard layout 1`] = `
           href="/settings"
         >
           <svg
-            class="dusk-icon dusk-icon--size--normal dusk-anchor-button__icon"
+            class="dusk-icon dusk-icon--size--large dusk-anchor-button__icon"
             role="graphics-symbol"
             viewBox="0 0 24 24"
           >

--- a/src/routes/(app)/settings/+page.svelte
+++ b/src/routes/(app)/settings/+page.svelte
@@ -15,7 +15,10 @@
 
 <section class="settings">
 	<header class="settings__header">
-		<AnchorButton href="/dashboard" icon={{ path: mdiArrowLeftCircleOutline }} variant="text"/>
+		<AnchorButton
+			href="/dashboard"
+			icon={{ path: mdiArrowLeftCircleOutline, size: "large" }}
+			variant="text"/>
 		<h2>
 			Settings
 		</h2>

--- a/src/routes/(app)/settings/__tests__/__snapshots__/page.spec.js.snap
+++ b/src/routes/(app)/settings/__tests__/__snapshots__/page.spec.js.snap
@@ -14,7 +14,7 @@ exports[`Settings > should render the settings page 1`] = `
         href="/dashboard"
       >
         <svg
-          class="dusk-icon dusk-icon--size--normal dusk-anchor-button__icon"
+          class="dusk-icon dusk-icon--size--large dusk-anchor-button__icon"
           role="graphics-symbol"
           viewBox="0 0 24 24"
         >

--- a/src/routes/components-showcase/AnchorButtons.svelte
+++ b/src/routes/components-showcase/AnchorButtons.svelte
@@ -142,3 +142,21 @@
 		variant="text"
 	/>
 </section>
+<section>
+	<AnchorButton
+		href="http://example.com"
+		icon={{ path: mdiHome, size: "large" }}
+		text="Anchor text"
+	/>
+	<AnchorButton
+		href="http://example.com"
+		text="Anchor text"
+		icon={{ path: mdiHome, size: "large" }}
+		variant="text"
+	/>
+	<AnchorButton
+		href="http://example.com"
+		icon={{ path: mdiHome, size: "large" }}
+		variant="text"
+	/>
+</section>

--- a/src/routes/components-showcase/IconButtons.svelte
+++ b/src/routes/components-showcase/IconButtons.svelte
@@ -84,3 +84,14 @@
 		variant="text"
 	/>
 </section>
+<section>
+	<Button
+		icon={{ path: mdiHome, size: "large" }}
+		variant="text"
+	/>
+	<Button
+		disabled={true}
+		icon={{ path: mdiHome, size: "large" }}
+		variant="text"
+	/>
+</section>

--- a/src/routes/components-showcase/LabeledButtons.svelte
+++ b/src/routes/components-showcase/LabeledButtons.svelte
@@ -109,3 +109,20 @@
 		variant="text"
 	/>
 </section>
+<section>
+	<Button
+		icon={{ path: mdiHome, size: "large" }}
+		tabindex=""
+		text="Some text"
+	/>
+	<Button
+		icon={{ path: mdiHome, size: "large" }}
+		size="small"
+		text="Some text"
+	/>
+	<Button
+		icon={{ path: mdiHome, size: "large" }}
+		text="Some text"
+		variant="text"
+	/>
+</section>


### PR DESCRIPTION
This PR:

- Adds icon size prop to Icons when used in Buttons
- Tweaks the Back button on the Settings page to use the larger icon style
- Tweaks the linked network status and the settings button on the dashboard to use the larger icon style
- Wraps the network, `Dusk Testnet`, in a `p` tag, so that we don't have text within a div without a proper markup
- Updates the components showcase to showcase the buttons with larger icons

Visuals:
<img width="456" alt="Screenshot 2023-11-26 at 17 59 22" src="https://github.com/dusk-network/web-wallet/assets/34094428/1d7e8e86-10b7-446f-bbb6-5f385b81e8ab">

<img width="451" alt="Screenshot 2023-11-26 at 17 59 28" src="https://github.com/dusk-network/web-wallet/assets/34094428/6bc89eed-6b6c-4d4a-8c40-1f4d69ce2df8">
