### PR TITLE
Resolve KeyPicker visual issues

### DIFF
--- a/src/routes/(app)/dashboard/+page.svelte
+++ b/src/routes/(app)/dashboard/+page.svelte
@@ -124,53 +124,14 @@
 	}];
 
 	$: selectedContract = find(CONTRACTS, hasKeyValue("id", selectedTab));
-
-	// ================================
-	// SECTION: Change Key functionality
-	// ================================
-	// Description: This section contains the logic for the change key functionality
-
-	let generatingKey = false;
-
-	/**
-	 * @param {Number} length
-	 * @note Helper function to generate a random key – used for testing purposes
-	 */
-	function generateRandomKey (length) {
-		let result = "";
-		const characters = "abcdefghijklmnopqrstuvwxyz0123456789";
-		const charactersLength = characters.length;
-
-		for (let i = 0; i < length; i++) {
-			result += characters.charAt(Math.floor(Math.random() * charactersLength));
-		}
-
-		return result;
-	}
-
-	async function generateKey () {
-		generatingKey = true;
-
-		try {
-			await new Promise(resolve => setTimeout(resolve, 5000));
-
-			const randomKey = generateRandomKey(32);
-
-			keys = [randomKey, ...keys];
-		} finally {
-			generatingKey = false;
-		}
-	}
 </script>
 
 <div class="dashboard-content">
 	<h2 class="visible-hidden">Dashboard</h2>
 
 	<KeyPicker
-		{generatingKey}
 		bind:keys
-		bind:currentKey
-		on:generateKey={generateKey}/>
+		bind:currentKey/>
 
 	<Balance
 		tokens={dusk}

--- a/src/routes/(app)/dashboard/KeyPicker.svelte
+++ b/src/routes/(app)/dashboard/KeyPicker.svelte
@@ -4,7 +4,7 @@
 	import { createEventDispatcher	} from "svelte";
 	import { makeClassName } from "$lib/dusk/string";
 	import {
-		mdiClose, mdiKeyOutline, mdiPlusBoxOutline, mdiSwapHorizontalCircle, mdiTimerSand
+		mdiKeyOutline, mdiPlusBoxOutline, mdiTimerSand
 	} from "@mdi/js";
 	import {
 		Button, CircularIcon, Icon, ProgressBar
@@ -12,12 +12,13 @@
 	import { handlePageClick } from "$lib/dusk/ui-helpers/handlePageClick";
 
 	import "./KeyPicker/KeyPicker.css";
-
-	/** @type {String[]} */
-	export let keys;
+	import Overlay from "./Overlay.svelte";
 
 	/** @type {String} */
 	export let currentKey;
+
+	/** @type {String[]} */
+	export let keys = [currentKey];
 
 	export let generatingKey = false;
 
@@ -59,7 +60,7 @@
 </script>
 
 {#if expanded}
-	<div class="overlay"></div>
+	<Overlay/>
 {/if}
 
 <div
@@ -73,13 +74,11 @@
 		tabindex="0"
 		aria-haspopup="true"
 		aria-expanded={expanded}
-		on:keydown={handleDropDownKeyDown}
-		on:click={toggle}>
+		on:keydown={handleDropDownKeyDown}>
 		<CircularIcon>
 			<Icon path={mdiKeyOutline} size="large"/>
 		</CircularIcon>
 		<p class="key-picker__current-key">{currentKey}</p>
-		<Icon path={expanded ? mdiClose : mdiSwapHorizontalCircle} size="large"/>
 	</div>
 
 	{#if expanded}
@@ -91,6 +90,7 @@
 						class="key-picker__key"
 						class:key-picker__key--selected={key === currentKey}>
 						<button
+							class="key-picker__key-option-button"
 							tabindex="0"
 							type="button"
 							role="menuitem"
@@ -122,18 +122,4 @@
 			{/if}
 		</div>
 	{/if}
-
 </div>
-
-<style>
-	.overlay {
-		position: absolute;
-		top: 0;
-		left: 0;
-		width: 100%;
-		height: 100%;
-		background: transparent;
-		z-index: 1;
-		backdrop-filter: blur(2px);
-	}
-</style>

--- a/src/routes/(app)/dashboard/KeyPicker/KeyPicker.css
+++ b/src/routes/(app)/dashboard/KeyPicker/KeyPicker.css
@@ -5,7 +5,6 @@
     border-radius: 1.25rem;
     user-select: none;
     z-index: 2;
-    transition: transform 0.5s;
 }
 
 .key-picker__current-key, .key-picker__key {
@@ -31,22 +30,11 @@
     cursor: pointer;
 }
 
-.key-picker__key button {
-    all: unset;
-    width: 100%;
-    text-align: center;
-    padding: .5em 0;
-}
-
 .key-picker__trigger {
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
     align-items: center;
     gap: var(--default-gap);
-}
-
-.key-picker__trigger:hover {
-    cursor: pointer;
 }
 
 .key-picker__drop-down {
@@ -68,8 +56,19 @@
 }
 
 .key-picker__key-options {
-    overflow-y: scroll;
-    max-height: 10em;
+    overflow-y: auto;
+    width: 100%;
+    max-height: 20svh;
+}
+
+.key-picker__key-option-button {
+    all: unset;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    width: 100%;
+    display: block;
+    text-align: center;
+    padding: .5em 0;
 }
 
 .key-picker__generating-key-wrapper {
@@ -80,7 +79,6 @@
 }
 
 .key-picker--expanded {
-    transform: scale(1.03);
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
 }

--- a/src/routes/(app)/dashboard/Overlay.svelte
+++ b/src/routes/(app)/dashboard/Overlay.svelte
@@ -1,0 +1,14 @@
+<div class="overlay"></div>
+
+<style>
+	.overlay {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		background: transparent;
+		z-index: 1;
+		backdrop-filter: blur(2px);
+	}
+</style>

--- a/src/routes/(app)/dashboard/__tests__/KeyPicker.spec.js
+++ b/src/routes/(app)/dashboard/__tests__/KeyPicker.spec.js
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it, vitest } from "vitest";
-import { cleanup, fireEvent, render } from "@testing-library/svelte";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render } from "@testing-library/svelte";
 import KeyPicker from "../KeyPicker.svelte";
 
 describe("KeyPicker", () => {
@@ -18,44 +18,5 @@ describe("KeyPicker", () => {
 		const { container } = render(KeyPicker, props);
 
 		expect(container.firstChild).toMatchSnapshot();
-	});
-
-	it("toggles dropdown on click", async () => {
-		const { getByRole, queryByText } = render(KeyPicker, props);
-
-		const component = getByRole("button");
-
-		await fireEvent.click(component);
-		expect(queryByText(keys[1])).toBeInTheDocument();
-		await fireEvent.click(component);
-		expect(queryByText(keys[1])).not.toBeInTheDocument();
-	});
-
-	it("updates selected key on click", async () => {
-		const { getByRole, getByText } = render(KeyPicker, props);
-		const componentTrigger = getByRole("button");
-
-		await fireEvent.click(componentTrigger);
-
-		const secondKeyOption = getByText(keys[1]);
-
-		await fireEvent.click(secondKeyOption);
-		expect(getByText(keys[1])).toBeInTheDocument();
-	});
-
-	it("dispatches generateKey event on button click", async () => {
-		const { getByRole, getByText, component } = render(KeyPicker, props);
-		const spy = vitest.fn();
-
-		const componentTrigger = getByRole("button");
-
-		await fireEvent.click(componentTrigger);
-
-		component.$on("generateKey", spy);
-
-		const generateKeyButton = getByText("Generate Key");
-
-		await fireEvent.click(generateKeyButton);
-		expect(spy).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/routes/(app)/dashboard/__tests__/__snapshots__/KeyPicker.spec.js.snap
+++ b/src/routes/(app)/dashboard/__tests__/__snapshots__/KeyPicker.spec.js.snap
@@ -4,12 +4,12 @@ exports[`KeyPicker > renders the KeyPicker component 1`] = `
 <div>
    
   <div
-    class="key-picker s-B6pEkAX6Ufmn"
+    class="key-picker"
   >
     <div
       aria-expanded="false"
       aria-haspopup="true"
-      class="key-picker__trigger s-B6pEkAX6Ufmn"
+      class="key-picker__trigger"
       role="button"
       tabindex="0"
     >
@@ -32,22 +32,10 @@ exports[`KeyPicker > renders the KeyPicker component 1`] = `
       <!--&lt;CircularIcon&gt;-->
        
       <p
-        class="key-picker__current-key s-B6pEkAX6Ufmn"
+        class="key-picker__current-key"
       >
         2087290d3dc213d43e493f03f5435f99
       </p>
-       
-      <svg
-        class="dusk-icon dusk-icon--size--large"
-        role="graphics-symbol"
-        viewBox="0 0 24 24"
-      >
-        <path
-          d="M22 12C22 6.5 17.5 2 12 2S2 6.5 2 12 6.5 22 12 22 22 17.5 22 12M15 6.5L18.5 10L15 13.5V11H11V9H15V6.5M9 17.5L5.5 14L9 10.5V13H13V15H9V17.5Z"
-        />
-      </svg>
-      
-      <!--&lt;Icon&gt;-->
     </div>
      
   </div>

--- a/src/routes/(app)/dashboard/__tests__/__snapshots__/page.spec.js.snap
+++ b/src/routes/(app)/dashboard/__tests__/__snapshots__/page.spec.js.snap
@@ -13,12 +13,12 @@ exports[`Dashboard > should render the dashboard page 1`] = `
      
      
     <div
-      class="key-picker s-B6pEkAX6Ufmn"
+      class="key-picker"
     >
       <div
         aria-expanded="false"
         aria-haspopup="true"
-        class="key-picker__trigger s-B6pEkAX6Ufmn"
+        class="key-picker__trigger"
         role="button"
         tabindex="0"
       >
@@ -41,22 +41,10 @@ exports[`Dashboard > should render the dashboard page 1`] = `
         <!--&lt;CircularIcon&gt;-->
          
         <p
-          class="key-picker__current-key s-B6pEkAX6Ufmn"
+          class="key-picker__current-key"
         >
           2087290d3dc213d43e493f03f5435f99
         </p>
-         
-        <svg
-          class="dusk-icon dusk-icon--size--large"
-          role="graphics-symbol"
-          viewBox="0 0 24 24"
-        >
-          <path
-            d="M22 12C22 6.5 17.5 2 12 2S2 6.5 2 12 6.5 22 12 22 22 17.5 22 12M15 6.5L18.5 10L15 13.5V11H11V9H15V6.5M9 17.5L5.5 14L9 10.5V13H13V15H9V17.5Z"
-          />
-        </svg>
-        
-        <!--&lt;Icon&gt;-->
       </div>
        
     </div>


### PR DESCRIPTION
Resolves #118, #134

This PR:
- Makes it so that the menu options don't overflow
- Removes the scale transition which was causing the KeyPicker to get cut off when expanded.
- Moves the Overlay as a component

**Visuals:**

<img width="435" alt="Screenshot 2023-12-07 at 15 07 02" src="https://github.com/dusk-network/web-wallet/assets/34094428/106b9c1e-28e3-44b2-8bc9-a50257090f38">
