### PR TITLE
Occurrences of Anchors have duplicated rel props

### DIFF
--- a/src/lib/dusk/components/Anchor/Anchor.svelte
+++ b/src/lib/dusk/components/Anchor/Anchor.svelte
@@ -1,15 +1,7 @@
 <svelte:options immutable={true}/>
 
 <script>
-
-	/**
-	 * When a target attribute is used the component automatically
-	 * adds the "noopener" and "noreferrer" strings to the `rel` attribute.
-	 * @see https://mathiasbynens.github.io/rel-noopener/
-	 */
-
 	import { makeClassName } from "$lib/dusk/string";
-
 	import "./Anchor.css";
 
 	/** @type {String | Undefined} */
@@ -17,12 +9,6 @@
 
 	/** @type {String} */
 	export let href;
-
-	/** @type {String | Undefined} */
-	export let rel = undefined;
-
-	/** @type {String | Undefined} */
-	export let target = undefined;
 </script>
 
 <a
@@ -30,8 +16,6 @@
 	class={makeClassName(["dusk-anchor", className])}
 	{href}
 	on:click
-	rel={target ? makeClassName([rel, "noopener", "noreferrer"]) : rel}
-	{target}
 >
 	<slot/>
 </a>

--- a/src/lib/dusk/components/__tests__/Anchor.spec.js
+++ b/src/lib/dusk/components/__tests__/Anchor.spec.js
@@ -14,9 +14,9 @@ describe("Anchor", () => {
 	const baseProps = {
 		href: "https://example.com"
 	};
+
 	const baseOptions = {
-		props: baseProps,
-		target: document.body
+		props: baseProps
 	};
 
 	afterEach(cleanup);
@@ -33,17 +33,6 @@ describe("Anchor", () => {
 			className: "foo bar",
 			href: "https://dusk.network",
 			title: "Some title"
-		};
-		const { container } = renderWithSimpleContent(Anchor, { ...baseOptions, props });
-
-		expect(container.firstChild).toMatchSnapshot();
-	});
-
-	it("should add \"noopener\" and \"noreferrer\" values to the rel attribute if a target is used", () => {
-		const props = {
-			...baseProps,
-			rel: "external",
-			target: "_blank"
 		};
 		const { container } = renderWithSimpleContent(Anchor, { ...baseOptions, props });
 

--- a/src/lib/dusk/components/__tests__/__snapshots__/Anchor.spec.js.snap
+++ b/src/lib/dusk/components/__tests__/__snapshots__/Anchor.spec.js.snap
@@ -1,37 +1,34 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Anchor > should add "noopener" and "noreferrer" values to the rel attribute if a target is used 1`] = `
-<a
-  class="dusk-anchor"
-  href="https://example.com"
-  rel="external noopener noreferrer"
-  target="_blank"
->
-  <span>
-    some text
-  </span>
-</a>
-`;
-
 exports[`Anchor > should pass additional class names and attributes to the rendered element 1`] = `
-<a
-  class="dusk-anchor foo bar"
-  href="https://dusk.network"
-  title="Some title"
->
-  <span>
-    some text
-  </span>
-</a>
+<div>
+  <a
+    class="dusk-anchor foo bar"
+    href="https://dusk.network"
+    title="Some title"
+  >
+    <span>
+      some text
+    </span>
+  </a>
+  <!--&lt;Anchor&gt;-->
+  
+  <!--&lt;SlotContent&gt;-->
+</div>
 `;
 
 exports[`Anchor > should render the Anchor component 1`] = `
-<a
-  class="dusk-anchor"
-  href="https://example.com"
->
-  <span>
-    some text
-  </span>
-</a>
+<div>
+  <a
+    class="dusk-anchor"
+    href="https://example.com"
+  >
+    <span>
+      some text
+    </span>
+  </a>
+  <!--&lt;Anchor&gt;-->
+  
+  <!--&lt;SlotContent&gt;-->
+</div>
 `;

--- a/src/lib/dusk/components/dusk.components.d.ts
+++ b/src/lib/dusk/components/dusk.components.d.ts
@@ -21,7 +21,7 @@ type WizardButtonProps = {
 	action?: () => void,
 }
 
-type IconSize = "normal" | "large";
+type IconSize = "small" | "normal" | "large";
 
 type GroupedSelectOptions = Record<string, SelectOption[] | string[]>;
 

--- a/src/routes/(app)/dashboard/Contract/Operations/Send.svelte
+++ b/src/routes/(app)/dashboard/Contract/Operations/Send.svelte
@@ -234,10 +234,10 @@
 						<AnchorButton
 							href={`https://explorer.dusk.network/transactions/transaction?id=${hash}`}
 							on:click={resetOperationStore}
-							rel="noopener noreferrer"
-							target="_blank"
 							text="VIEW ON BLOCK EXPLORER"
 							variant="secondary"
+							rel="noopener noreferrer"
+							target="_blank"
 						/>
 					{/if}
 				</svelte:fragment>

--- a/src/routes/(app)/dashboard/Contract/Operations/Stake.svelte
+++ b/src/routes/(app)/dashboard/Contract/Operations/Stake.svelte
@@ -205,10 +205,10 @@
 						<AnchorButton
 							href={`https://explorer.dusk.network/transactions/transaction?id=${hash}`}
 							on:click={resetOperationStore}
-							rel="noopener noreferrer"
-							target="_blank"
 							text="VIEW ON BLOCK EXPLORER"
 							variant="secondary"
+							rel="noopener noreferrer"
+							target="_blank"
 						/>
 					{/if}
 				</svelte:fragment>

--- a/src/routes/(app)/dashboard/Transactions.svelte
+++ b/src/routes/(app)/dashboard/Transactions.svelte
@@ -48,8 +48,8 @@
 						<samp>
 							<Anchor
 								href="https://explorer.dusk.network/transactions/transaction?id={transaction.id}"
-								target="_blank"
 								rel="noopener noreferrer"
+								target="_blank"
 							>
 								{middleEllipsis(
 									transaction.id,

--- a/src/routes/(app)/dashboard/__tests__/__snapshots__/page.spec.js.snap
+++ b/src/routes/(app)/dashboard/__tests__/__snapshots__/page.spec.js.snap
@@ -1199,7 +1199,7 @@ exports[`Dashboard > should render the dashboard page with the transactions afte
               <a
                 class="dusk-anchor"
                 href="https://explorer.dusk.network/transactions/transaction?id=tg874534tddsghdtst54hdfh795h"
-                rel="noopener noreferrer noopener noreferrer"
+                rel="noopener noreferrer"
                 target="_blank"
               >
                 tg874534tddsghdtst54hdfh795h
@@ -1305,7 +1305,7 @@ exports[`Dashboard > should render the dashboard page with the transactions afte
               <a
                 class="dusk-anchor"
                 href="https://explorer.dusk.network/transactions/transaction?id=tg874534tddsghdtst54hdfh794h"
-                rel="noopener noreferrer noopener noreferrer"
+                rel="noopener noreferrer"
                 target="_blank"
               >
                 tg874534tddsghdtst54hdfh794h
@@ -1385,7 +1385,7 @@ exports[`Dashboard > should render the dashboard page with the transactions afte
               <a
                 class="dusk-anchor"
                 href="https://explorer.dusk.network/transactions/transaction?id=tg874534tddsghdtst54hdfh793h"
-                rel="noopener noreferrer noopener noreferrer"
+                rel="noopener noreferrer"
                 target="_blank"
               >
                 tg874534tddsghdtst54hdfh793h
@@ -1465,7 +1465,7 @@ exports[`Dashboard > should render the dashboard page with the transactions afte
               <a
                 class="dusk-anchor"
                 href="https://explorer.dusk.network/transactions/transaction?id=tg874534tddsghdtst54hdfh792h"
-                rel="noopener noreferrer noopener noreferrer"
+                rel="noopener noreferrer"
                 target="_blank"
               >
                 tg874534tddsghdtst54hdfh792h
@@ -1571,7 +1571,7 @@ exports[`Dashboard > should render the dashboard page with the transactions afte
               <a
                 class="dusk-anchor"
                 href="https://explorer.dusk.network/transactions/transaction?id=tg874534tddsghdtst54hdfh791h"
-                rel="noopener noreferrer noopener noreferrer"
+                rel="noopener noreferrer"
                 target="_blank"
               >
                 tg874534tddsghdtst54hdfh791h

--- a/src/routes/(welcome)/setup/TermsOfService.svelte
+++ b/src/routes/(welcome)/setup/TermsOfService.svelte
@@ -13,7 +13,10 @@
 <section class="flex flex-col flex-1">
 	<Card heading="Terms &amp; Privacy Policy">
 		<div class="flex flex-col gap-1">
-			<p>Our <Anchor href="https://dusk.network/privacy-policy/" target="_blank" rel="noopener noreferrer">Terms &amp; Privacy Policy</Anchor> govern your use of our services,
+			<p>Our <Anchor
+				href="https://dusk.network/privacy-policy/"
+				rel="noopener noreferrer"
+				target="_blank">Terms &amp; Privacy Policy</Anchor> govern your use of our services,
 			including data handling and user responsibilities.
 			Your privacy and security are our top priorities.</p>
 			<div class="flex gap-1 w-100">

--- a/src/routes/(welcome)/setup/create/__tests__/__snapshots__/page.spec.js.snap
+++ b/src/routes/(welcome)/setup/create/__tests__/__snapshots__/page.spec.js.snap
@@ -31,7 +31,7 @@ exports[`Create > should render the Terms of Service step of the Create flow 1`]
             <a
               class="dusk-anchor"
               href="https://dusk.network/privacy-policy/"
-              rel="noopener noreferrer noopener noreferrer"
+              rel="noopener noreferrer"
               target="_blank"
             >
               Terms & Privacy Policy

--- a/src/routes/(welcome)/setup/restore/__tests__/__snapshots__/page.spec.js.snap
+++ b/src/routes/(welcome)/setup/restore/__tests__/__snapshots__/page.spec.js.snap
@@ -31,7 +31,7 @@ exports[`Restore > should render the Terms of Service step of the Restore flow 1
             <a
               class="dusk-anchor"
               href="https://dusk.network/privacy-policy/"
-              rel="noopener noreferrer noopener noreferrer"
+              rel="noopener noreferrer"
               target="_blank"
             >
               Terms & Privacy Policy

--- a/src/style/dusk-components/icon.css
+++ b/src/style/dusk-components/icon.css
@@ -13,6 +13,11 @@
 	width: calc(var(--icon-size) * var(--scaler));
 }
 
+.dusk-icon--size--small {
+	height: calc(var(--icon-size) / var(--scaler));
+	width: calc(var(--icon-size) / var(--scaler));
+}
+
 .dusk-icon--circular {
 	display: flex;
 	border-radius: 50%;


### PR DESCRIPTION
Resolves #398

**This PR:**
- Resolves the occurrences where `rel` properties were repeated twice
- Introduces a `small` icon size

**Visuals:**
<img width="623" alt="Screenshot 2024-01-15 at 15 26 30" src="https://github.com/dusk-network/web-wallet/assets/34094428/804c6aa7-7d1c-48e2-b60c-454e19d962d5">
