### PR TITLE
Fix Tabs appearance when only one tab is visible

### DIFF
--- a/src/routes/(app)/dashboard/+page.svelte
+++ b/src/routes/(app)/dashboard/+page.svelte
@@ -119,8 +119,7 @@
 			<div
 				class="tabs__panel"
 				class:tabs__panel--first={selectedTab === enabledContracts[0].id}
-				class:tabs__panel--last={ enabledContracts.length > 1
-					&& selectedTab === last(enabledContracts).id}
+				class:tabs__panel--last={selectedTab === last(enabledContracts).id}
 			>
 				{#key selectedTab}
 					<div in:fade class="tabs__contract">


### PR DESCRIPTION
Resolves #458

<img width="625" alt="Screenshot 2024-01-29 at 15 02 41" src="https://github.com/dusk-network/web-wallet/assets/34094428/ca7684cd-13c9-4531-9168-117d1233546a">
