### PR TITLE
Strengthen persisted wallet encryption

### DIFF
--- a/src/lib/services/loginInfoStorage/__tests__/index.spec.js
+++ b/src/lib/services/loginInfoStorage/__tests__/index.spec.js
@@ -1,17 +1,27 @@
 import { afterEach, describe, expect, it } from "vitest";
-import { isNull, mapValuesWith, unless } from "lamb";
-
 import { bytesToBase64 } from "$lib/dusk/base64";
 
 import loginInfoStorage from "..";
 
 describe("loginInfoStorage", () => {
   const storeKey = `${CONFIG.LOCAL_STORAGE_APP_KEY}-login`;
-  const valuesToArray = unless(
-    isNull,
-    mapValuesWith((v) => [...v])
-  );
-  const valuesToBase64 = mapValuesWith(bytesToBase64);
+  /** @param {WalletEncryptInfo | null} info */
+  const byteValuesToArray = (info) =>
+    info === null
+      ? null
+      : {
+          ...info,
+          data: [...info.data],
+          iv: [...info.iv],
+          salt: [...info.salt],
+        };
+  /** @param {WalletEncryptInfo} info */
+  const valuesToBase64 = (info) => ({
+    ...info,
+    data: bytesToBase64(info.data),
+    iv: bytesToBase64(info.iv),
+    salt: bytesToBase64(info.salt),
+  });
   const loginInfo = {
     data: new TextEncoder().encode("some string"),
     iv: Uint8Array.of(1, 2, 3, 4),
@@ -35,7 +45,9 @@ describe("loginInfoStorage", () => {
     });
 
     // The `toStrictEqual` matcher doesn't play well with typed arrays in this case
-    expect(valuesToArray(result)).toStrictEqual(valuesToArray(loginInfo));
+    expect(byteValuesToArray(result)).toStrictEqual(
+      byteValuesToArray(loginInfo)
+    );
   });
 
   it("should return `null` if there is no login info stored", () => {
@@ -55,5 +67,18 @@ describe("loginInfoStorage", () => {
     const stored = localStorage.getItem(storeKey);
 
     expect(stored).toBe(storedInfo);
+  });
+
+  it("should preserve the numeric encryption version", () => {
+    const versionedLoginInfo = { ...loginInfo, version: 1 };
+
+    loginInfoStorage.set(versionedLoginInfo);
+
+    expect(byteValuesToArray(loginInfoStorage.get())).toStrictEqual(
+      byteValuesToArray(versionedLoginInfo)
+    );
+    expect(localStorage.getItem(storeKey)).toBe(
+      JSON.stringify(valuesToBase64(versionedLoginInfo))
+    );
   });
 });

--- a/src/lib/services/loginInfoStorage/index.js
+++ b/src/lib/services/loginInfoStorage/index.js
@@ -1,13 +1,34 @@
-import { compose, isNull, mapValuesWith, unless } from "lamb";
-
 import { base64ToBytes, bytesToBase64 } from "$lib/dusk/base64";
 
 const storeKey = `${CONFIG.LOCAL_STORAGE_APP_KEY}-login`;
-const fromStorageString = unless(
-  isNull,
-  compose(mapValuesWith(base64ToBytes), JSON.parse)
+const decode = /** @type {(value: string) => Uint8Array<ArrayBuffer>} */ (
+  base64ToBytes
 );
-const toStorageString = compose(JSON.stringify, mapValuesWith(bytesToBase64));
+
+/** @param {string | null} value */
+const fromStorageString = (value) => {
+  if (value === null) {
+    return null;
+  }
+
+  const { data, iv, salt, version } = JSON.parse(value);
+
+  return {
+    data: decode(data),
+    iv: decode(iv),
+    salt: decode(salt),
+    ...(version === undefined ? {} : { version }),
+  };
+};
+
+/** @param {WalletEncryptInfo} info */
+const toStorageString = ({ data, iv, salt, version }) =>
+  JSON.stringify({
+    data: bytesToBase64(data),
+    iv: bytesToBase64(iv),
+    salt: bytesToBase64(salt),
+    ...(version === undefined ? {} : { version }),
+  });
 
 const loginInfoStorage = {
   /** @returns {WalletEncryptInfo | null} */

--- a/src/lib/wallet/__tests__/decryptBuffer.spec.js
+++ b/src/lib/wallet/__tests__/decryptBuffer.spec.js
@@ -10,6 +10,6 @@ describe("decryptBuffer", () => {
     const encryptInfo = await encryptBuffer(plaintext, pwd);
     const decrypted = await decryptBuffer(encryptInfo, pwd);
 
-    expect(decrypted.toString()).toBe(plaintext.buffer.toString());
+    expect([...new Uint8Array(decrypted)]).toStrictEqual([...plaintext]);
   });
 });

--- a/src/lib/wallet/__tests__/decryptMnemonic.spec.js
+++ b/src/lib/wallet/__tests__/decryptMnemonic.spec.js
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { decryptMnemonic, encryptMnemonic, generateMnemonic } from "..";
+import {
+  decryptMnemonic,
+  encryptBuffer,
+  encryptMnemonic,
+  generateMnemonic,
+} from "..";
 
 describe("decryptMnemonic", () => {
   const mnemonic = generateMnemonic();
@@ -11,5 +16,24 @@ describe("decryptMnemonic", () => {
     const decrypted = await decryptMnemonic(mnemonicEncryptInfo, pwd);
 
     expect(decrypted).toBe(mnemonic);
+  });
+
+  it("should decrypt legacy, unversioned mnemonic data", async () => {
+    const mnemonicEncryptInfo = await encryptBuffer(
+      new TextEncoder().encode(mnemonic),
+      pwd,
+      10_000
+    );
+    const decrypted = await decryptMnemonic(mnemonicEncryptInfo, pwd);
+
+    expect(decrypted).toBe(mnemonic);
+  });
+
+  it("should reject unsupported encryption versions", async () => {
+    const mnemonicEncryptInfo = await encryptMnemonic(mnemonic, pwd);
+
+    await expect(
+      decryptMnemonic({ ...mnemonicEncryptInfo, version: 2 }, pwd)
+    ).rejects.toThrow("Unsupported wallet encryption version");
   });
 });

--- a/src/lib/wallet/__tests__/encryptMnemonic.spec.js
+++ b/src/lib/wallet/__tests__/encryptMnemonic.spec.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { encryptMnemonic, generateMnemonic } from "..";
 
@@ -7,17 +7,28 @@ describe("encryptMnemonic", () => {
   const pwd = "some password";
 
   it("should be able to encrypt the mnemonic phrase using the given password", async () => {
+    const deriveKeySpy = vi.spyOn(crypto.subtle, "deriveKey");
     const result = await encryptMnemonic(mnemonic, pwd);
 
     expect(result).toMatchObject({
       data: expect.any(Uint8Array),
       iv: expect.any(Uint8Array),
       salt: expect.any(Uint8Array),
+      version: 1,
     });
     expect(result.data.toString()).not.toBe(
       new TextEncoder().encode(mnemonic).toString()
     );
     expect(result.iv.length).toBe(12);
     expect(result.salt.length).toBe(32);
+    expect(deriveKeySpy).toHaveBeenCalledWith(
+      expect.objectContaining({ iterations: 600_000 }),
+      expect.any(CryptoKey),
+      expect.any(Object),
+      true,
+      ["encrypt", "decrypt"]
+    );
+
+    deriveKeySpy.mockRestore();
   });
 });

--- a/src/lib/wallet/__tests__/migrateLoginInfo.spec.js
+++ b/src/lib/wallet/__tests__/migrateLoginInfo.spec.js
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import loginInfoStorage from "$lib/services/loginInfoStorage";
+
+import encryptBuffer from "../encryptBuffer";
+import generateMnemonic from "../generateMnemonic";
+import migrateLoginInfo from "../migrateLoginInfo";
+
+describe("migrateLoginInfo", () => {
+  afterEach(() => {
+    loginInfoStorage.remove();
+  });
+
+  it("should preserve legacy login info if migration fails", async () => {
+    const legacyLoginInfo = await encryptBuffer(
+      new TextEncoder().encode(generateMnemonic()),
+      "some password",
+      10_000
+    );
+
+    loginInfoStorage.set(legacyLoginInfo);
+
+    await expect(
+      migrateLoginInfo(legacyLoginInfo, "wrong password")
+    ).rejects.toThrow();
+
+    const storedLoginInfo = loginInfoStorage.get();
+
+    expect(storedLoginInfo).not.toBeNull();
+
+    if (!storedLoginInfo) {
+      throw new Error("Expected stored login info");
+    }
+
+    for (const field of /** @type {const} */ (["data", "iv", "salt"])) {
+      expect([...storedLoginInfo[field]]).toStrictEqual([
+        ...legacyLoginInfo[field],
+      ]);
+    }
+    expect(storedLoginInfo.version).toBeUndefined();
+  });
+});

--- a/src/lib/wallet/decryptBuffer.js
+++ b/src/lib/wallet/decryptBuffer.js
@@ -3,11 +3,12 @@ import getDerivedKey from "./getDerivedKey";
 /**
  * @param {WalletEncryptInfo} encryptInfo
  * @param {string} pwd
+ * @param {number} [iterations]
  * @returns {Promise<ArrayBuffer>}
  */
-async function decryptBuffer(encryptInfo, pwd) {
+async function decryptBuffer(encryptInfo, pwd, iterations) {
   const { data, iv, salt } = encryptInfo;
-  const key = await getDerivedKey(pwd, salt);
+  const key = await getDerivedKey(pwd, salt, iterations);
 
   return await crypto.subtle.decrypt({ iv, name: "AES-GCM" }, key, data);
 }

--- a/src/lib/wallet/decryptMnemonic.js
+++ b/src/lib/wallet/decryptMnemonic.js
@@ -1,4 +1,5 @@
 import decryptBuffer from "./decryptBuffer";
+import { getWalletEncryptionIterations } from "./walletEncryption";
 
 /**
  * @param {WalletEncryptInfo} encryptInfo
@@ -6,6 +7,12 @@ import decryptBuffer from "./decryptBuffer";
  * @returns {Promise<string>}
  */
 const decryptMnemonic = async (encryptInfo, pwd) =>
-  new TextDecoder().decode(await decryptBuffer(encryptInfo, pwd));
+  new TextDecoder().decode(
+    await decryptBuffer(
+      encryptInfo,
+      pwd,
+      getWalletEncryptionIterations(encryptInfo.version)
+    )
+  );
 
 export default decryptMnemonic;

--- a/src/lib/wallet/encryptBuffer.js
+++ b/src/lib/wallet/encryptBuffer.js
@@ -3,12 +3,13 @@ import getDerivedKey from "./getDerivedKey";
 /**
  * @param {BufferSource} buffer
  * @param {string} pwd
+ * @param {number} [iterations]
  * @returns {Promise<WalletEncryptInfo>}
  */
-async function encryptBuffer(buffer, pwd) {
+async function encryptBuffer(buffer, pwd, iterations) {
   const salt = crypto.getRandomValues(new Uint8Array(32));
   const iv = crypto.getRandomValues(new Uint8Array(12));
-  const key = await getDerivedKey(pwd, salt);
+  const key = await getDerivedKey(pwd, salt, iterations);
   const data = new Uint8Array(
     await crypto.subtle.encrypt({ iv, name: "AES-GCM" }, key, buffer)
   );

--- a/src/lib/wallet/encryptMnemonic.js
+++ b/src/lib/wallet/encryptMnemonic.js
@@ -1,11 +1,21 @@
 import encryptBuffer from "./encryptBuffer";
+import {
+  CURRENT_PBKDF2_ITERATIONS,
+  CURRENT_WALLET_ENCRYPTION_VERSION,
+} from "./walletEncryption";
 
 /**
  * @param {string} mnemonic
  * @param {string} pwd
  * @returns {Promise<WalletEncryptInfo>}
  */
-const encryptMnemonic = async (mnemonic, pwd) =>
-  await encryptBuffer(new TextEncoder().encode(mnemonic), pwd);
+const encryptMnemonic = async (mnemonic, pwd) => ({
+  ...(await encryptBuffer(
+    new TextEncoder().encode(mnemonic),
+    pwd,
+    CURRENT_PBKDF2_ITERATIONS
+  )),
+  version: CURRENT_WALLET_ENCRYPTION_VERSION,
+});
 
 export default encryptMnemonic;

--- a/src/lib/wallet/getDerivedKey.js
+++ b/src/lib/wallet/getDerivedKey.js
@@ -1,3 +1,5 @@
+import { LEGACY_PBKDF2_ITERATIONS } from "./walletEncryption";
+
 /**
  * @param {String} pwd
  * @returns {Promise<CryptoKey>}
@@ -14,13 +16,18 @@ const getKeyMaterial = (pwd) =>
 /**
  * @param {String} pwd
  * @param {Uint8Array<ArrayBuffer>} salt
+ * @param {number} [iterations]
  * @returns {Promise<CryptoKey>}
  */
-const getDerivedKey = async (pwd, salt) =>
+const getDerivedKey = async (
+  pwd,
+  salt,
+  iterations = LEGACY_PBKDF2_ITERATIONS
+) =>
   crypto.subtle.deriveKey(
     {
       hash: "SHA-256",
-      iterations: 10000,
+      iterations,
       name: "PBKDF2",
       salt,
     },

--- a/src/lib/wallet/index.js
+++ b/src/lib/wallet/index.js
@@ -6,6 +6,7 @@ export { default as generateMnemonic } from "./generateMnemonic";
 export { default as getAddressInfo } from "./getAddressInfo";
 export { default as getSeedFromMnemonic } from "./getSeedFromMnemonic";
 export { default as initializeWallet } from "./initializeWallet";
+export { default as migrateLoginInfo } from "./migrateLoginInfo";
 export { default as notesArrayToMap } from "./notesArrayToMap";
 export { default as profileGeneratorFrom } from "./profileGeneratorFrom";
 export { default as refreshLocalStoragePasswordInfo } from "./refreshLocalStoragePasswordInfo";

--- a/src/lib/wallet/migrateLoginInfo.js
+++ b/src/lib/wallet/migrateLoginInfo.js
@@ -1,0 +1,24 @@
+import loginInfoStorage from "$lib/services/loginInfoStorage";
+
+import decryptMnemonic from "./decryptMnemonic";
+import encryptMnemonic from "./encryptMnemonic";
+
+/**
+ * @param {WalletEncryptInfo} loginInfo
+ * @param {string} pwd
+ * @returns {Promise<boolean>}
+ */
+async function migrateLoginInfo(loginInfo, pwd) {
+  if (loginInfo.version !== undefined) {
+    return false;
+  }
+
+  const mnemonic = await decryptMnemonic(loginInfo, pwd);
+  const migratedLoginInfo = await encryptMnemonic(mnemonic, pwd);
+
+  loginInfoStorage.set(migratedLoginInfo);
+
+  return true;
+}
+
+export default migrateLoginInfo;

--- a/src/lib/wallet/wallet.d.ts
+++ b/src/lib/wallet/wallet.d.ts
@@ -2,4 +2,5 @@ type WalletEncryptInfo = {
   data: Uint8Array<ArrayBuffer>;
   iv: Uint8Array<ArrayBuffer>;
   salt: Uint8Array<ArrayBuffer>;
+  version?: number;
 };

--- a/src/lib/wallet/walletEncryption.js
+++ b/src/lib/wallet/walletEncryption.js
@@ -1,0 +1,19 @@
+export const CURRENT_WALLET_ENCRYPTION_VERSION = 1;
+export const LEGACY_PBKDF2_ITERATIONS = 10_000;
+export const CURRENT_PBKDF2_ITERATIONS = 600_000;
+
+/**
+ * @param {number | undefined} version
+ * @returns {number}
+ */
+export function getWalletEncryptionIterations(version) {
+  if (version === undefined) {
+    return LEGACY_PBKDF2_ITERATIONS;
+  }
+
+  if (version === CURRENT_WALLET_ENCRYPTION_VERSION) {
+    return CURRENT_PBKDF2_ITERATIONS;
+  }
+
+  throw new Error(`Unsupported wallet encryption version: ${version}`);
+}

--- a/src/routes/(welcome)/unlock/+page.svelte
+++ b/src/routes/(welcome)/unlock/+page.svelte
@@ -22,6 +22,7 @@
   import {
     decryptMnemonic,
     getSeedFromMnemonic,
+    migrateLoginInfo,
     profileGeneratorFrom,
     validateMnemonic,
   } from "$lib/wallet";
@@ -71,9 +72,21 @@
       ? getSeedFromInfo(loginInfo)
       : (mnemonic) => getSeedFromMnemonicAsync(mnemonic.toLowerCase());
 
-    getSeed(secretText.trim())
+    const secret = secretText.trim();
+
+    getSeed(secret)
       .then(checkLocalData)
-      .then((profileGenerator) => walletStore.init(profileGenerator))
+      .then(async (profileGenerator) => {
+        await walletStore.init(profileGenerator);
+
+        if (loginInfo) {
+          try {
+            await migrateLoginInfo(loginInfo, secret);
+          } catch {
+            // A failed migration should not prevent an otherwise valid unlock.
+          }
+        }
+      })
       .then(() => goto("/dashboard"))
       .catch((err) => {
         if (err instanceof MismatchedWalletError) {

--- a/src/routes/(welcome)/unlock/__tests__/page.spec.js
+++ b/src/routes/(welcome)/unlock/__tests__/page.spec.js
@@ -17,6 +17,8 @@ import { getAsHTMLElement } from "$lib/dusk/test-helpers";
 import * as navigation from "$lib/navigation";
 import { settingsStore, walletStore } from "$lib/stores";
 import {
+  decryptMnemonic,
+  encryptBuffer,
   encryptMnemonic,
   generateMnemonic,
   getSeedFromMnemonic,
@@ -36,6 +38,11 @@ describe("Unlock Wallet", async () => {
   const mnemonic = generateMnemonic();
   const pwd = "some pwd";
   const loginInfo = await encryptMnemonic(mnemonic, pwd);
+  const legacyLoginInfo = await encryptBuffer(
+    new TextEncoder().encode(mnemonic),
+    pwd,
+    10_000
+  );
   const seed = getSeedFromMnemonic(mnemonic);
   const userId = await profileGeneratorFrom(seed)
     .then(getKey("default"))
@@ -292,6 +299,68 @@ describe("Unlock Wallet", async () => {
       expect(initSpy).toHaveBeenCalledWith(expect.any(ProfileGenerator));
       expect(gotoSpy).toHaveBeenCalledTimes(1);
       expect(gotoSpy).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  describe("Legacy password migration", () => {
+    afterEach(() => {
+      loginInfoStorage.remove();
+    });
+
+    it("should migrate legacy login info after unlocking the expected wallet", async () => {
+      loginInfoStorage.set(legacyLoginInfo);
+      settingsStore.update(setKey("userId", userId));
+
+      const { container } = render(UnlockWallet, {});
+      const form = getAsHTMLElement(container, "form");
+      const textInput = getTextInput(container);
+
+      await fireEvent.input(textInput, { target: { value: pwd } });
+      await fireEvent.submit(form, { currentTarget: form });
+      await waitForGoto();
+
+      const migratedLoginInfo = loginInfoStorage.get();
+
+      expect(migratedLoginInfo).not.toBeNull();
+
+      if (!migratedLoginInfo) {
+        throw new Error("Expected migrated login info");
+      }
+
+      expect(migratedLoginInfo.version).toBe(1);
+      expect(await decryptMnemonic(migratedLoginInfo, pwd)).toBe(mnemonic);
+      expect(initSpy).toHaveBeenCalledTimes(1);
+      expect(gotoSpy).toHaveBeenCalledWith("/dashboard");
+    });
+
+    it("should preserve legacy login info if the wallet identity does not match", async () => {
+      loginInfoStorage.set(legacyLoginInfo);
+      settingsStore.update(setKey("userId", "some-user-id"));
+
+      const { container } = render(UnlockWallet, {});
+      const form = getAsHTMLElement(container, "form");
+      const textInput = getTextInput(container);
+
+      await fireEvent.input(textInput, { target: { value: pwd } });
+      await fireEvent.submit(form, { currentTarget: form });
+      await waitForGoto();
+
+      const storedLoginInfo = loginInfoStorage.get();
+
+      expect(storedLoginInfo).not.toBeNull();
+
+      if (!storedLoginInfo) {
+        throw new Error("Expected stored login info");
+      }
+
+      for (const field of /** @type {const} */ (["data", "iv", "salt"])) {
+        expect([...storedLoginInfo[field]]).toStrictEqual([
+          ...legacyLoginInfo[field],
+        ]);
+      }
+      expect(storedLoginInfo.version).toBeUndefined();
+      expect(initSpy).not.toHaveBeenCalled();
+      expect(gotoSpy).toHaveBeenCalledWith("/setup/restore");
     });
   });
 });


### PR DESCRIPTION
## Summary

- version persisted mnemonic encryption and raise its PBKDF2-HMAC-SHA256 work factor from 10,000 to 600,000 iterations
- continue decrypting existing unversioned records with the legacy parameters
- transparently migrate legacy records only after the password, wallet identity, and wallet initialization succeed
- reject unknown encryption versions and leave legacy data intact if migration fails
- keep the generic in-memory buffer encryption at its existing cost so routine wallet operations are not slowed down

## Why

Persisted wallet mnemonics currently use an unversioned PBKDF2 configuration with 10,000 iterations. Raising that value directly would make existing wallets unreadable, while raising the generic buffer helper's default would also penalize short-lived session encryption.

The versioned format gives persisted wallets a stronger work factor and a safe path for future KDF changes without breaking existing users.

## User impact

New wallet records immediately use the stronger parameters. Existing password-protected wallets continue to unlock and are upgraded after a successful unlock. On desktop Chrome, 600,000 iterations took a median 64.2 ms over 15 warmed runs, compared with 1.2 ms for the legacy setting.

## Validation

- `npm run checks` — formatting, lint, type checking, and 634 tests pass
- `npm run build`
- focused migration coverage verifies legacy decryption, the 600,000-iteration WebCrypto call, successful re-encryption, identity-gated migration, failure preservation, and unknown-version rejection
- desktop Chrome 151 benchmark: 64.2 ms median, 59.8–70.5 ms range over 15 warmed runs