### PR TITLE
Lock inactive wallet sessions after 15 minutes

### DIFF
--- a/src/lib/navigation/__tests__/startInactivityTimer.spec.js
+++ b/src/lib/navigation/__tests__/startInactivityTimer.spec.js
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import startInactivityTimer from "../startInactivityTimer";
+
+describe("startInactivityTimer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ now: 0 });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should expire after the configured period without activity", async () => {
+    const onInactive = vi.fn();
+
+    startInactivityTimer(onInactive, 1_000);
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(onInactive).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(onInactive).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["keydown", "pointerdown", "wheel"])(
+    "should restart the deadline on %s activity",
+    async (event) => {
+      const onInactive = vi.fn();
+
+      startInactivityTimer(onInactive, 1_000);
+      await vi.advanceTimersByTimeAsync(900);
+      window.dispatchEvent(new Event(event));
+      await vi.advanceTimersByTimeAsync(999);
+
+      expect(onInactive).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(onInactive).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it("should enforce an elapsed deadline when browser timers were delayed", () => {
+    const onInactive = vi.fn();
+
+    startInactivityTimer(onInactive, 1_000);
+    vi.setSystemTime(1_000);
+    document.dispatchEvent(new Event("visibilitychange"));
+
+    expect(onInactive).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not let late activity renew an elapsed deadline", () => {
+    const onInactive = vi.fn();
+
+    startInactivityTimer(onInactive, 1_000);
+    vi.setSystemTime(1_000);
+    window.dispatchEvent(new Event("pointerdown"));
+
+    expect(onInactive).toHaveBeenCalledTimes(1);
+  });
+
+  it("should stop tracking activity when disposed", async () => {
+    const onInactive = vi.fn();
+    const stop = startInactivityTimer(onInactive, 1_000);
+
+    stop();
+    window.dispatchEvent(new Event("pointerdown"));
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(onInactive).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/navigation/index.js
+++ b/src/lib/navigation/index.js
@@ -1,4 +1,8 @@
 export { default as logout } from "./logout";
+export {
+  INACTIVITY_TIMEOUT,
+  default as startInactivityTimer,
+} from "./startInactivityTimer";
 export { default as addBasePath } from "./addBasePath";
 export { default as goto } from "./goto";
 export { default as redirect } from "./redirect";

--- a/src/lib/navigation/startInactivityTimer.js
+++ b/src/lib/navigation/startInactivityTimer.js
@@ -1,0 +1,70 @@
+export const INACTIVITY_TIMEOUT = 15 * 60 * 1000;
+
+const activityEvents = ["keydown", "pointerdown", "wheel"];
+
+/**
+ * @param {() => unknown} onInactive
+ * @param {number} [timeout]
+ * @returns {() => void}
+ */
+function startInactivityTimer(onInactive, timeout = INACTIVITY_TIMEOUT) {
+  let expiresAt = Date.now() + timeout;
+  let timeoutId = 0;
+  let stopped = false;
+
+  function stop() {
+    if (!stopped) {
+      stopped = true;
+      window.clearTimeout(timeoutId);
+      activityEvents.forEach((event) =>
+        window.removeEventListener(event, handleActivity)
+      );
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    }
+  }
+
+  function expire() {
+    if (!stopped) {
+      stop();
+      onInactive();
+    }
+  }
+
+  function checkDeadline() {
+    if (Date.now() >= expiresAt) {
+      expire();
+    } else {
+      arm();
+    }
+  }
+
+  function arm() {
+    window.clearTimeout(timeoutId);
+    timeoutId = window.setTimeout(checkDeadline, expiresAt - Date.now());
+  }
+
+  function handleActivity() {
+    if (Date.now() >= expiresAt) {
+      expire();
+    } else {
+      expiresAt = Date.now() + timeout;
+      arm();
+    }
+  }
+
+  function handleVisibilityChange() {
+    if (document.visibilityState === "visible") {
+      checkDeadline();
+    }
+  }
+
+  activityEvents.forEach((event) =>
+    window.addEventListener(event, handleActivity)
+  );
+  document.addEventListener("visibilitychange", handleVisibilityChange);
+  arm();
+
+  return stop;
+}
+
+export default startInactivityTimer;

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -1,5 +1,9 @@
 <script>
-  import { logout } from "$lib/navigation";
+  import { onMount } from "svelte";
+
+  import { logout, startInactivityTimer } from "$lib/navigation";
+
+  onMount(() => startInactivityTimer(() => logout(false)));
 
   /** @param {StorageEvent} event */
   function handleStorageChange(event) {

--- a/src/routes/(app)/__tests__/layout.spec.js
+++ b/src/routes/(app)/__tests__/layout.spec.js
@@ -46,7 +46,7 @@ describe("App layout.js", () => {
 });
 
 describe("App layout.svelte", () => {
-  const logoutSpy = vi.spyOn(navigation, "logout");
+  const logoutSpy = vi.spyOn(navigation, "logout").mockResolvedValue();
   const removeListenerSpy = vi.spyOn(window, "removeEventListener");
   const key = `${CONFIG.LOCAL_STORAGE_APP_KEY}-preferences`;
   const storage = {
@@ -122,5 +122,22 @@ describe("App layout.svelte", () => {
 
     expect(removeListenerSpy).not.toHaveBeenCalled();
     expect(logoutSpy).not.toHaveBeenCalled();
+  });
+
+  it("should logout the user after fifteen minutes without activity", async () => {
+    walletStore.abortSync();
+    vi.useFakeTimers();
+
+    try {
+      render(Layout);
+
+      await vi.advanceTimersByTimeAsync(navigation.INACTIVITY_TIMEOUT);
+
+      expect(logoutSpy).toHaveBeenCalledTimes(1);
+      expect(logoutSpy).toHaveBeenCalledWith(false);
+    } finally {
+      walletStore.abortSync();
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- lock the authenticated Dusk wallet after 15 minutes without meaningful user activity
- reset the deadline on pointer, keyboard, or wheel input
- enforce an absolute deadline when a background tab resumes after browser timer throttling
- dispose the timer and event listeners when the authenticated layout unmounts

## Why

An unlocked wallet currently remains available until the user logs out, another tab replaces the wallet, or the page is closed. That leaves signing access available indefinitely on an unattended device.

The authenticated layout is the narrowest enforcement boundary: it exists only while the wallet is unlocked and can reuse the existing logout path, which resets `walletStore` before returning to the unlock flow.

## User impact

After 15 minutes without deliberate input, the wallet returns to the unlock page. Activity starts a fresh 15-minute window. Merely hiding the page does not immediately lock it, so ordinary external-wallet and WalletConnect handoffs are not interrupted; if the deadline elapses while the browser throttles timers, it is enforced when the page becomes visible again.

## Validation

- `npm run checks` — formatting, lint, type checking, and 636 tests pass
- `npm run build`
- focused tests cover exact expiry, pointer/keyboard/wheel renewal, delayed background timers, late-activity bypass attempts, cleanup, and authenticated-layout logout wiring