### PR TITLE
Release retained wallet material on reset

### DIFF
--- a/src/lib/stores/__tests__/walletStore.spec.js
+++ b/src/lib/stores/__tests__/walletStore.spec.js
@@ -95,6 +95,7 @@ describe("Wallet store", async () => {
     .spyOn(WalletTreasury.prototype, "setCachedStakeInfo")
     .mockResolvedValue(undefined);
   const setProfilesSpy = vi.spyOn(WalletTreasury.prototype, "setProfiles");
+  const treasuryResetSpy = vi.spyOn(WalletTreasury.prototype, "reset");
   const treasuryUpdateSpy = vi.spyOn(WalletTreasury.prototype, "update");
 
   vi.spyOn(networkStore, "checkBlock").mockResolvedValue(true);
@@ -240,7 +241,7 @@ describe("Wallet store", async () => {
         stakeInfoSpy.mock.invocationCallOrder[0]
       );
 
-      expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+      expect(clearTimeoutSpy).toHaveBeenCalledTimes(2);
 
       /**
        * The first call is caused by the timeout in the network
@@ -248,7 +249,7 @@ describe("Wallet store", async () => {
        * made in the wallet store.
        */
       expect(setTimeoutSpy).toHaveBeenCalledTimes(2);
-      expect(clearTimeoutSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      expect(clearTimeoutSpy.mock.invocationCallOrder.at(-1)).toBeLessThan(
         setTimeoutSpy.mock.invocationCallOrder[1]
       );
 
@@ -266,6 +267,24 @@ describe("Wallet store", async () => {
       expect(get(walletStore)).toStrictEqual(initialState);
 
       await vi.runOnlyPendingTimersAsync();
+    });
+
+    it("should not publish profiles from an initialization reset before it completes", async () => {
+      const pendingProfile = Promise.withResolvers();
+      const delayedGenerator = {
+        default: pendingProfile.promise,
+        next: vi.fn().mockResolvedValue(defaultProfile),
+      };
+
+      // @ts-expect-error The delayed generator models the required interface.
+      const initPromise = walletStore.init(delayedGenerator);
+
+      walletStore.reset();
+      pendingProfile.resolve(defaultProfile);
+      await initPromise;
+
+      expect(get(walletStore)).toStrictEqual(initialState);
+      expect(setProfilesSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -329,6 +348,54 @@ describe("Wallet store", async () => {
       await vi.runAllTimersAsync();
     });
 
+    it("should abort during sync preflight without leaving the store busy", async () => {
+      const pendingSyncInfo = Promise.withResolvers();
+      const getCachedSyncInfoSpy = vi
+        .spyOn(WalletTreasury.prototype, "getCachedSyncInfo")
+        .mockReturnValueOnce(pendingSyncInfo.promise);
+
+      try {
+        const firstSync = walletStore.sync();
+
+        await vi.waitUntil(() => getCachedSyncInfoSpy.mock.calls.length === 1);
+
+        const secondSync = walletStore.sync();
+
+        expect(getCachedSyncInfoSpy).toHaveBeenCalledTimes(1);
+        expect(get(walletStore).syncStatus.isInProgress).toBe(true);
+
+        walletStore.abortSync();
+        pendingSyncInfo.resolve({
+          block: { hash: "", height: 0n },
+          bookmark: 0n,
+          lastFinalizedBlockHeight: 0n,
+        });
+
+        await Promise.all([firstSync, secondSync]);
+
+        expect(treasuryUpdateSpy).not.toHaveBeenCalled();
+        expect(get(walletStore).syncStatus).toStrictEqual({
+          error: expect.any(Error),
+          from: 0n,
+          isInProgress: false,
+          last: 0n,
+          progress: 0,
+        });
+
+        walletStore.sync();
+        await vi.advanceTimersByTimeAsync(AUTO_SYNC_INTERVAL - 1);
+
+        expect(treasuryUpdateSpy).toHaveBeenCalledTimes(1);
+        expect(get(walletStore).syncStatus).toStrictEqual(
+          initialState.syncStatus
+        );
+
+        walletStore.abortSync();
+      } finally {
+        getCachedSyncInfoSpy.mockRestore();
+      }
+    });
+
     it("should do nothing but stopping the auto-sync if there is no sync in progress", async () => {
       walletStore.abortSync();
 
@@ -336,6 +403,26 @@ describe("Wallet store", async () => {
       expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
 
       await vi.runAllTimersAsync();
+    });
+
+    it("should remain reset when an aborted sync settles", async () => {
+      const pendingUpdate = Promise.withResolvers();
+
+      treasuryUpdateSpy.mockImplementationOnce(() => pendingUpdate.promise);
+
+      const syncPromise = walletStore.sync();
+
+      await vi.waitUntil(() => treasuryUpdateSpy.mock.calls.length === 1);
+
+      treasuryResetSpy.mockClear();
+      walletStore.reset();
+      expect(get(walletStore)).toStrictEqual(initialState);
+      expect(treasuryResetSpy).toHaveBeenCalledTimes(1);
+
+      pendingUpdate.resolve(undefined);
+      await syncPromise;
+
+      expect(get(walletStore)).toStrictEqual(initialState);
     });
   });
 

--- a/src/lib/stores/walletStore.js
+++ b/src/lib/stores/walletStore.js
@@ -28,6 +28,8 @@ let syncController = null;
 /** @type {Promise<void> | null} */
 let syncPromise = null;
 
+let walletSession = 0;
+
 /** @type {WalletStoreContent} */
 const initialState = {
   balance: {
@@ -196,7 +198,7 @@ const updateStaticInfo = () =>
 /** @type {WalletStoreServices["abortSync"]} */
 const abortSync = () => {
   window.clearTimeout(autoSyncId);
-  syncPromise && syncController?.abort();
+  syncController?.abort();
   syncPromise = null;
 };
 
@@ -230,6 +232,9 @@ const getTransactionsHistory = async () => transactions;
 
 /** @type {WalletStoreServices["init"]} */
 async function init(profileGeneratorInstance, syncFromBlock) {
+  reset();
+  const session = walletSession;
+
   // Create two profiles by default
   const currentProfile = await profileGeneratorInstance.default;
   const secondProfile = await profileGeneratorInstance.next();
@@ -238,6 +243,10 @@ async function init(profileGeneratorInstance, syncFromBlock) {
   const cachedBalance = await treasury.getCachedBalance(currentProfile);
   const cachedStakeInfo = await treasury.getCachedStakeInfo(currentProfile);
   const minimumStake = await bookkeeper.minimumStake;
+
+  if (session !== walletSession) {
+    return;
+  }
 
   treasury.setProfiles(profiles);
 
@@ -253,14 +262,24 @@ async function init(profileGeneratorInstance, syncFromBlock) {
 
   sync(syncFromBlock)
     .then(() => {
-      settingsStore.update(setKey("userId", currentProfile.address.toString()));
+      if (session === walletSession) {
+        settingsStore.update(
+          setKey("userId", currentProfile.address.toString())
+        );
+      }
     })
-    .finally(updateStaticInfo);
+    .finally(async () => {
+      if (session === walletSession) {
+        await updateStaticInfo();
+      }
+    });
 }
 
 /** @type {WalletStoreServices["reset"]} */
 function reset() {
+  walletSession++;
   abortSync();
+  treasury.reset();
   set(initialState);
 }
 
@@ -304,8 +323,8 @@ const stake = async (amount, gas) =>
     .then(passThruWithEffects(observeTxRemoval));
 
 /** @type {WalletStoreServices["sync"]} */
-// eslint-disable-next-line max-statements
 async function sync(fromBlock) {
+  const session = walletSession;
   const store = get(walletStore);
 
   if (!store.initialized) {
@@ -326,82 +345,106 @@ async function sync(fromBlock) {
       },
     });
 
-    syncController = new AbortController();
+    const controller = new AbortController();
+    syncController = controller;
 
-    const { block, bookmark, lastFinalizedBlockHeight } =
-      await treasury.getCachedSyncInfo();
+    const currentSyncPromise = (async () => {
+      const { block, bookmark, lastFinalizedBlockHeight } =
+        await treasury.getCachedSyncInfo();
 
-    /** @type {bigint | Bookmark} */
-    let from;
+      /** @type {bigint | Bookmark} */
+      let from;
 
-    /*
-     * Unless the user wants to sync from a specific block height,
-     * we try to restart from the last stored bookmark.
-     * Before doing that we compare the block hash we have in cache
-     * with the hash at the same block height on the network: if
-     * they don't match then a block has been rejected, we can't
-     * use our bookmark, and our only safe option is to restart
-     * from the last finalized block we have cached.
-     */
-    if (fromBlock) {
-      from = fromBlock;
-    } else {
-      const isLocalCacheValid = await networkStore
-        .checkBlock(block.height, block.hash)
-        .catch(() => false);
+      /*
+       * Unless the user wants to sync from a specific block height,
+       * we try to restart from the last stored bookmark.
+       * Before doing that we compare the block hash we have in cache
+       * with the hash at the same block height on the network: if
+       * they don't match then a block has been rejected, we can't
+       * use our bookmark, and our only safe option is to restart
+       * from the last finalized block we have cached.
+       */
+      if (fromBlock) {
+        from = fromBlock;
+      } else {
+        const isLocalCacheValid = await networkStore
+          .checkBlock(block.height, block.hash)
+          .catch(() => false);
 
-      from = isLocalCacheValid
-        ? Bookmark.from(bookmark)
-        : lastFinalizedBlockHeight;
-    }
+        from = isLocalCacheValid
+          ? Bookmark.from(bookmark)
+          : lastFinalizedBlockHeight;
+      }
 
-    if (from === 0n) {
-      await treasury.clearCache();
-    }
+      if (from === 0n) {
+        await treasury.clearCache();
+      }
 
-    update((currentStore) => ({
-      ...currentStore,
-      syncStatus: {
-        ...currentStore.syncStatus,
-        from: from instanceof Bookmark ? block.height : from,
-      },
-    }));
+      if (controller.signal.aborted) {
+        throw new Error("Synchronization aborted");
+      }
 
-    syncPromise = Promise.resolve(syncController.signal)
-      .then(async (signal) => {
-        /** @type {(evt: CustomEvent) => void} */
-        const syncIterationListener = ({ detail }) => {
-          update((currentStore) => ({
-            ...currentStore,
-            syncStatus: {
-              ...currentStore.syncStatus,
-              last: detail.blocks.last,
-              progress: detail.progress,
-            },
-          }));
-        };
+      if (session !== walletSession) {
+        return;
+      }
 
-        await treasury.update(from, syncIterationListener, signal);
-      })
+      update((currentStore) => ({
+        ...currentStore,
+        syncStatus: {
+          ...currentStore.syncStatus,
+          from: from instanceof Bookmark ? block.height : from,
+        },
+      }));
+
+      /** @type {(evt: CustomEvent) => void} */
+      const syncIterationListener = ({ detail }) => {
+        if (session !== walletSession) {
+          return;
+        }
+
+        update((currentStore) => ({
+          ...currentStore,
+          syncStatus: {
+            ...currentStore.syncStatus,
+            last: detail.blocks.last,
+            progress: detail.progress,
+          },
+        }));
+      };
+
+      await treasury.update(from, syncIterationListener, controller.signal);
+    })()
       .then(() => {
-        if (syncController?.signal.aborted) {
+        if (controller.signal.aborted) {
           throw new Error("Synchronization aborted");
         }
       })
       .then(() => {
+        if (session !== walletSession) {
+          return;
+        }
+
         update((currentStore) => ({
           ...currentStore,
           syncStatus: initialState.syncStatus,
         }));
       })
       .then(() => {
+        if (session !== walletSession) {
+          return;
+        }
+
         window.clearTimeout(autoSyncId);
         autoSyncId = window.setTimeout(() => {
           sync().finally(updateStaticInfo);
         }, AUTO_SYNC_INTERVAL);
       })
       .catch((error) => {
-        syncController?.abort();
+        controller.abort();
+
+        if (session !== walletSession || syncController !== controller) {
+          return;
+        }
 
         update((currentStore) => ({
           ...currentStore,
@@ -415,11 +458,19 @@ async function sync(fromBlock) {
         }));
       })
       .finally(() => {
-        syncPromise = null;
+        if (syncPromise === currentSyncPromise) {
+          syncPromise = null;
+        }
+
+        if (syncController === controller) {
+          syncController = null;
+        }
       });
+
+    syncPromise = currentSyncPromise;
   }
 
-  return syncPromise;
+  await syncPromise;
 }
 
 /** @type {WalletStoreServices["transfer"]} */

--- a/src/lib/wallet-treasury/__tests__/index.spec.js
+++ b/src/lib/wallet-treasury/__tests__/index.spec.js
@@ -9,6 +9,7 @@ import {
   vi,
 } from "vitest";
 import { mapValues, mapWith, multiplyBy, pluckFrom } from "lamb";
+import { AccountSyncer, AddressSyncer } from "@dusk/w3sper";
 
 import mockedWalletStore from "$lib/mocks/mockedWalletStore";
 
@@ -178,6 +179,73 @@ describe("WalletTreasury", () => {
           },
         })
       ).rejects.toThrow();
+    });
+
+    it("should discard retained profiles and derived account state when reset", async () => {
+      const balancesSpy = vi.spyOn(AccountSyncer.prototype, "balances");
+      const stakesSpy = vi.spyOn(AccountSyncer.prototype, "stakes");
+      const notesSpy = vi.spyOn(AddressSyncer.prototype, "notes");
+
+      await walletTreasury.update(0n, () => {}, new AbortController().signal);
+
+      // @ts-expect-error We only need an index accepted by the treasury mock.
+      await expect(walletTreasury.account(0)).resolves.toBeDefined();
+
+      walletTreasury.reset();
+
+      // @ts-expect-error We only need an index accepted by the treasury mock.
+      await expect(walletTreasury.account(0)).rejects.toThrow();
+      // @ts-expect-error We only need an index accepted by the treasury mock.
+      await expect(walletTreasury.stakeInfo(0)).rejects.toThrow();
+
+      await walletTreasury.update(0n, () => {}, new AbortController().signal);
+
+      expect(balancesSpy).toHaveBeenLastCalledWith([]);
+      expect(stakesSpy).toHaveBeenLastCalledWith([]);
+      expect(notesSpy).toHaveBeenLastCalledWith([], expect.any(Object));
+
+      balancesSpy.mockRestore();
+      stakesSpy.mockRestore();
+      notesSpy.mockRestore();
+    });
+
+    it("should remove sync listeners when an update fails", async () => {
+      const error = new Error("Unable to retrieve balances");
+      const balancesSpy = vi
+        .spyOn(AccountSyncer.prototype, "balances")
+        .mockRejectedValueOnce(error);
+      const addEventListenerSpy = vi.spyOn(
+        AddressSyncer.prototype,
+        "addEventListener"
+      );
+      const removeEventListenerSpy = vi.spyOn(
+        AddressSyncer.prototype,
+        "removeEventListener"
+      );
+
+      try {
+        await expect(
+          walletTreasury.update(0n, () => {}, new AbortController().signal)
+        ).rejects.toBe(error);
+
+        expect(addEventListenerSpy).toHaveBeenCalledTimes(2);
+        expect(removeEventListenerSpy.mock.calls).toStrictEqual(
+          addEventListenerSpy.mock.calls
+        );
+
+        await expect(
+          walletTreasury.update(0n, () => {}, new AbortController().signal)
+        ).resolves.toBeUndefined();
+
+        expect(addEventListenerSpy).toHaveBeenCalledTimes(4);
+        expect(removeEventListenerSpy.mock.calls).toStrictEqual(
+          addEventListenerSpy.mock.calls
+        );
+      } finally {
+        balancesSpy.mockRestore();
+        addEventListenerSpy.mockRestore();
+        removeEventListenerSpy.mockRestore();
+      }
     });
   });
 

--- a/src/lib/wallet-treasury/index.js
+++ b/src/lib/wallet-treasury/index.js
@@ -8,6 +8,8 @@ class WalletTreasury {
   /** @type {AccountBalance[]} */
   #accountBalances = [];
 
+  #generation = 0;
+
   #profiles;
 
   /** @type {StakeInfo[]} */
@@ -107,6 +109,13 @@ class WalletTreasury {
     return await walletCache.getSyncInfo();
   }
 
+  reset() {
+    this.#accountBalances = [];
+    this.#accountStakeInfo = [];
+    this.#profiles = [];
+    this.#generation++;
+  }
+
   /**
    * @param {Profile} profile
    * @param {WalletCacheBalanceInfo["balance"]} balance
@@ -127,7 +136,10 @@ class WalletTreasury {
 
   /** @param {Profile[]} profiles */
   setProfiles(profiles) {
+    this.#accountBalances = [];
+    this.#accountStakeInfo = [];
     this.#profiles = profiles;
+    this.#generation++;
   }
 
   /**
@@ -154,6 +166,12 @@ class WalletTreasury {
    */
   // eslint-disable-next-line max-statements
   async update(from, syncIterationListener, signal) {
+    const generation = this.#generation;
+    const ensureCurrent = () => {
+      if (generation !== this.#generation || signal.aborted) {
+        throw new Error("Synchronization aborted");
+      }
+    };
     let lastBlockHeight = 0n;
 
     /** @type {(evt: CustomEvent) => void} */
@@ -162,114 +180,137 @@ class WalletTreasury {
     };
     const accountSyncer = await networkStore.getAccountSyncer();
     const addressSyncer = await networkStore.getAddressSyncer();
+    const eventName = "synciteration";
+    const cleanup = () => {
+      // @ts-ignore
+      addressSyncer.removeEventListener(eventName, lastBlockHeightListener);
 
-    // @ts-ignore
-    addressSyncer.addEventListener("synciteration", lastBlockHeightListener);
+      // @ts-ignore
+      addressSyncer.removeEventListener(eventName, syncIterationListener);
+    };
+    let profiles = this.#profiles;
 
-    // @ts-ignore
-    addressSyncer.addEventListener("synciteration", syncIterationListener);
+    try {
+      ensureCurrent();
 
-    [this.#accountBalances, this.#accountStakeInfo] = await Promise.all([
-      accountSyncer.balances(this.#profiles),
-      accountSyncer.stakes(this.#profiles),
-    ]);
+      // @ts-ignore
+      addressSyncer.addEventListener(eventName, lastBlockHeightListener);
 
-    const notesStream = await addressSyncer.notes(this.#profiles, {
-      from,
-      signal,
-    });
+      // @ts-ignore
+      addressSyncer.addEventListener(eventName, syncIterationListener);
 
-    /**
-     * For each chunk of data in the stream we enrich the sync
-     * info with the block hash, that will be used to check that
-     * our local state is consistent with the remote one.
-     * This way we can ensure that if a user interrupts the sync
-     * while it's still in progress we can safely resume it from
-     * the stored bookmark if no block has been rejected in the
-     * meantime.
-     */
-    for await (const [notesInfo, streamSyncInfo] of notesStream) {
-      const notesSyncInfo = {
-        block: {
-          hash: await networkStore
-            .getBlockHashByHeight(streamSyncInfo.blockHeight)
-            .catch(() => ""),
-          height: streamSyncInfo.blockHeight,
-        },
-        bookmark: streamSyncInfo.bookmark,
-      };
-      await walletCache.addUnspentNotes(
-        walletCache.toCacheNotes(notesInfo, this.#profiles),
-        notesSyncInfo
-      );
-    }
+      const [accountBalances, accountStakeInfo] = await Promise.all([
+        accountSyncer.balances(profiles),
+        accountSyncer.stakes(profiles),
+      ]);
 
-    // gather all unspent nullifiers in the cache
-    const currentUnspentNullifiers =
-      await walletCache.getUnspentNotesNullifiers();
+      ensureCurrent();
+      this.#accountBalances = accountBalances;
+      this.#accountStakeInfo = accountStakeInfo;
 
-    /**
-     * Retrieving the nullifiers that are now spent.
-     *
-     * Currently `w3sper.js` returns an array of `ArrayBuffer`s
-     * instead of one of `Uint8Array<ArrayBuffer>`s, but we don't
-     * care as `ArrayBuffers` will be written in the
-     * database anyway.
-     */
-    const spentNullifiers = await addressSyncer.spent(currentUnspentNullifiers);
+      const notesStream = await addressSyncer.notes(profiles, {
+        from,
+        signal,
+      });
 
-    // update the cache with the spent nullifiers info
-    await walletCache.spendNotes(spentNullifiers);
+      ensureCurrent();
 
-    // gather all spent nullifiers in the cache
-    const currentSpentNullifiers =
-      await walletCache.getUnspentNotesNullifiers();
+      /**
+       * For each chunk of data in the stream we enrich the sync
+       * info with the block hash, that will be used to check that
+       * our local state is consistent with the remote one.
+       * This way we can ensure that if a user interrupts the sync
+       * while it's still in progress we can safely resume it from
+       * the stored bookmark if no block has been rejected in the
+       * meantime.
+       */
+      for await (const [notesInfo, streamSyncInfo] of notesStream) {
+        const notesSyncInfo = {
+          block: {
+            hash: await networkStore
+              .getBlockHashByHeight(streamSyncInfo.blockHeight)
+              .catch(() => ""),
+            height: streamSyncInfo.blockHeight,
+          },
+          bookmark: streamSyncInfo.bookmark,
+        };
 
-    /**
-     * Retrieving the nullifiers that are really spent given our
-     * list of spent nullifiers.
-     * We make this check because a block can be rejected and
-     * we may end up having some notes marked as spent in the
-     * cache, while they really aren't.
-     *
-     * Currently `w3sper.js` returns an array of `ArrayBuffer`s
-     * instead of one of `Uint8Array<ArrayBuffer>`s.
-     */
-    const reallySpentNullifiers = await addressSyncer.spent(
-      currentSpentNullifiers
-    );
+        ensureCurrent();
+        await walletCache.addUnspentNotes(
+          walletCache.toCacheNotes(notesInfo, profiles),
+          notesSyncInfo
+        );
+      }
 
-    /**
-     * As the previous `addressSyncer.spent` call returns a subset of
-     * our spent nullifiers, we can skip this operation if the lengths
-     * are the same.
-     */
-    if (reallySpentNullifiers.length !== currentSpentNullifiers.length) {
-      const nullifiersToUnspend = walletCache.nullifiersDifference(
-        currentSpentNullifiers,
-        map(reallySpentNullifiers, (buf) => new Uint8Array(buf))
+      profiles = [];
+      ensureCurrent();
+
+      // gather all unspent nullifiers in the cache
+      const currentUnspentNullifiers =
+        await walletCache.getUnspentNotesNullifiers();
+
+      /**
+       * Retrieving the nullifiers that are now spent.
+       *
+       * Currently `w3sper.js` returns an array of `ArrayBuffer`s
+       * instead of one of `Uint8Array<ArrayBuffer>`s, but we don't
+       * care as `ArrayBuffers` will be written in the
+       * database anyway.
+       */
+      const spentNullifiers = await addressSyncer.spent(
+        currentUnspentNullifiers
       );
 
-      await walletCache.unspendNotes(nullifiersToUnspend);
+      // update the cache with the spent nullifiers info
+      await walletCache.spendNotes(spentNullifiers);
+
+      // gather all spent nullifiers in the cache
+      const currentSpentNullifiers =
+        await walletCache.getUnspentNotesNullifiers();
+
+      /**
+       * Retrieving the nullifiers that are really spent given our
+       * list of spent nullifiers.
+       * We make this check because a block can be rejected and
+       * we may end up having some notes marked as spent in the
+       * cache, while they really aren't.
+       *
+       * Currently `w3sper.js` returns an array of `ArrayBuffer`s
+       * instead of one of `Uint8Array<ArrayBuffer>`s.
+       */
+      const reallySpentNullifiers = await addressSyncer.spent(
+        currentSpentNullifiers
+      );
+
+      /**
+       * As the previous `addressSyncer.spent` call returns a subset of
+       * our spent nullifiers, we can skip this operation if the lengths
+       * are the same.
+       */
+      if (reallySpentNullifiers.length !== currentSpentNullifiers.length) {
+        const nullifiersToUnspend = walletCache.nullifiersDifference(
+          currentSpentNullifiers,
+          map(reallySpentNullifiers, (buf) => new Uint8Array(buf))
+        );
+
+        await walletCache.unspendNotes(nullifiersToUnspend);
+      }
+
+      /**
+       * We enrich the sync info by retrieving the hash of the last
+       * processed block and the height of the last finalized block.
+       * We'll use this information at the start of the sync
+       * to determine if a block has been rejected, so that we can
+       * fix our local cache state by syncing from the last finalized
+       * block height.
+       */
+      await walletCache.setSyncInfo(
+        await this.#getEnrichedSyncInfo(lastBlockHeight)
+      );
+    } finally {
+      profiles = [];
+      cleanup();
     }
-
-    /**
-     * We enrich the sync info by retrieving the hash of the last
-     * processed block and the height of the last finalized block.
-     * We'll use this information at the start of the sync
-     * to determine if a block has been rejected, so that we can
-     * fix our local cache state by syncing from the last finalized
-     * block height.
-     */
-    await walletCache.setSyncInfo(
-      await this.#getEnrichedSyncInfo(lastBlockHeight)
-    );
-
-    // @ts-ignore
-    addressSyncer.removeEventListener("synciteration", lastBlockHeightListener);
-
-    // @ts-ignore
-    addressSyncer.removeEventListener("synciteration", syncIterationListener);
   }
 
   /**


### PR DESCRIPTION
## Summary

- clear retained profiles and derived account state when the wallet resets
- invalidate treasury synchronization that belongs to an earlier profile generation
- prevent delayed initialization and synchronization from republishing state after logout

## Why

`walletStore.reset()` cleared the public Svelte store, but the long-lived treasury still retained its profile array and derived account state. Asynchronous initialization or synchronization could also settle after reset and mutate the cleared store.

The shared reset path now releases those references and advances a wallet-session identifier. Work from an earlier session is ignored, while ordinary initialization, synchronization, and automatic synchronization retain their existing behavior.

This releases JavaScript references to wallet material; it does not claim guaranteed memory zeroization by the browser runtime.

## Validation

- `npm run checks`
- `npm run build`
- focused treasury and wallet-store lifecycle tests, including delayed initialization and an aborted sync settling after reset
