### PR TITLE
Normalize BEP20 bridge memos before submission

### DIFF
--- a/src/lib/components/Send/Send.svelte
+++ b/src/lib/components/Send/Send.svelte
@@ -150,9 +150,11 @@
   // Validate that the total amount is within the user's available balance.
   $: isTotalAmountWithinAvailableBalance = totalAmount <= availableBalance;
 
+  $: transactionMemo = isSendingToBep20Bridge ? memo.trim() : memo;
+
   // For BEP20 bridge operations, memo is required and must be a valid EVM address
   $: isMemoValidForBridge =
-    !isSendingToBep20Bridge || (memo.trim() !== "" && isMemoValid);
+    !isSendingToBep20Bridge || (transactionMemo !== "" && isMemoValid);
 
   $: isNextButtonDisabled = !(
     isSendAmountValid &&
@@ -185,11 +187,10 @@
   }
 
   $: {
-    const trimmedMemo = memo.trim();
-    if (isSendingToBep20Bridge && trimmedMemo !== "") {
+    if (isSendingToBep20Bridge && transactionMemo !== "") {
       // If sending to the BEP20 bridge and a memo is provided,
       // it must be a valid EVM address.
-      isMemoValid = isValidEvmAddress(trimmedMemo);
+      isMemoValid = isValidEvmAddress(transactionMemo);
     } else {
       // Otherwise (not sending to BEP20 bridge, or memo is empty),
       // the memo is not considered invalid from an EVM format perspective.
@@ -457,13 +458,13 @@
           </dd>
         </dl>
 
-        {#if memo}
+        {#if transactionMemo}
           <dl class="operation__review-transaction">
             <dt class="review-transaction__label">
               <span>Memo</span>
             </dt>
             <dd class="operation__review-memo">
-              <span>{memo}</span>
+              <span>{transactionMemo}</span>
             </dd>
           </dl>
         {/if}
@@ -478,7 +479,7 @@
         operation={execute(
           sendToAddress,
           sendAmountInLux,
-          memo,
+          transactionMemo,
           gasPrice,
           gasLimit
         )}

--- a/src/lib/components/__tests__/Send.spec.js
+++ b/src/lib/components/__tests__/Send.spec.js
@@ -412,6 +412,7 @@ describe("Send", () => {
     it("should perform a transfer for the desired amount, with a memo, give a success message and supply a link to see the transaction in the explorer", async () => {
       const { getByRole, getByText } = render(Send, baseProps);
       const addressInput = getByRole("textbox");
+      const memo = " abc-example-memo ";
 
       await fireEvent.input(addressInput, {
         target: { value: shieldedAddress },
@@ -424,7 +425,7 @@ describe("Send", () => {
 
       await fireEvent.input(amountInput, { target: { value: amount } });
       await fireEvent.input(memoInput, {
-        target: { value: "abc-example-memo" },
+        target: { value: memo },
       });
 
       await fireEvent.click(getByRole("button", { name: "Next" }));
@@ -436,7 +437,7 @@ describe("Send", () => {
       expect(baseProps.execute).toHaveBeenCalledWith(
         shieldedAddress,
         duskToLux(amount),
-        "abc-example-memo",
+        memo,
         baseProps.gasSettings.gasPrice,
         baseProps.gasSettings.gasLimit
       );
@@ -446,6 +447,44 @@ describe("Send", () => {
       expect(getByText("Transaction created")).toBeInTheDocument();
       expect(explorerLink).toHaveAttribute("target", "_blank");
       expect(explorerLink).toHaveAttribute("href", expectedExplorerLink);
+    });
+
+    it("should trim a BEP20 bridge memo before review and execution", async () => {
+      const { container, getByRole } = render(Send, baseProps);
+      const evmAddress = "0x9876543210987654321098765432109876543210";
+
+      await fireEvent.input(getByRole("textbox"), {
+        target: { value: bep20BridgeAddress },
+      });
+      await fireEvent.click(getByRole("button", { name: "Next" }));
+
+      await fireEvent.input(getByRole("spinbutton"), {
+        target: { value: amount },
+      });
+      await fireEvent.input(
+        getAsHTMLElement(container, ".operation__send-memo"),
+        { target: { value: ` \n${evmAddress}\t ` } }
+      );
+      await fireEvent.click(getByRole("button", { name: "Next" }));
+
+      const reviewMemo = getAsHTMLElement(
+        container,
+        ".operation__review-memo span"
+      );
+
+      expect(reviewMemo).toHaveTextContent(evmAddress);
+
+      await fireEvent.click(getByRole("button", { name: "SEND" }));
+      await vi.advanceTimersToNextTimerAsync();
+
+      expect(baseProps.execute).toHaveBeenCalledTimes(1);
+      expect(baseProps.execute).toHaveBeenCalledWith(
+        bep20BridgeAddress,
+        duskToLux(amount),
+        evmAddress,
+        baseProps.gasSettings.gasPrice,
+        baseProps.gasSettings.gasLimit
+      );
     });
 
     it("should show an error message if the transfer fails", async () => {


### PR DESCRIPTION
## Summary

- normalize surrounding whitespace in BEP20 bridge destination memos
- use the same normalized memo for validation, review, and transaction execution
- preserve ordinary non-bridge memos unchanged

## Why

Bridge memo validation previously checked a trimmed copy of the memo, while the review screen and transaction used the original value. A valid EVM address with trailing clipboard whitespace could therefore pass validation but be submitted with that whitespace intact.

## Validation

- `npx vitest --run src/lib/components/__tests__/Send.spec.js`
- `npm run checks`
- `npm run build`
